### PR TITLE
Fix MCP realtime parity for task mutations

### DIFF
--- a/apps/api/src/routes/mcp-sse.ts
+++ b/apps/api/src/routes/mcp-sse.ts
@@ -265,6 +265,14 @@ async function executeMcpTool(
       const deleteResult = await taskService.delete(taskId, null);
       if (!deleteResult.ok) throw deleteResult.error;
       result = { deleted: true, taskId };
+
+      const projectInfo = await projectService.getById(taskResult.value.projectId);
+      if (projectInfo.ok) {
+        publishEvent(projectInfo.value.workspaceId, REALTIME_EVENTS.TASK_DELETED, {
+          id: taskId,
+          projectId: taskResult.value.projectId,
+        });
+      }
       break;
     }
 
@@ -319,6 +327,11 @@ async function executeMcpTool(
 
       if (!moveResult.ok) throw moveResult.error;
       result = moveResult.value;
+
+      const projectInfo = await projectService.getById(taskResult.value.projectId);
+      if (projectInfo.ok) {
+        publishEvent(projectInfo.value.workspaceId, REALTIME_EVENTS.TASK_MOVED, moveResult.value);
+      }
       break;
     }
 
@@ -349,6 +362,11 @@ async function executeMcpTool(
       const updatedTask = await taskService.getById(taskId);
       if (!updatedTask.ok) throw updatedTask.error;
       result = updatedTask.value;
+
+      const projectInfo = await projectService.getById(taskResult.value.projectId);
+      if (projectInfo.ok) {
+        publishEvent(projectInfo.value.workspaceId, REALTIME_EVENTS.TASK_UPDATED, updatedTask.value);
+      }
       break;
     }
 

--- a/apps/api/src/routes/mcp.ts
+++ b/apps/api/src/routes/mcp.ts
@@ -298,6 +298,14 @@ mcp.post(
           const deleteResult = await taskService.delete(taskId, oauthAuth.userId);
           if (!deleteResult.ok) throw deleteResult.error;
           result = { deleted: true, taskId };
+
+          const projectInfo = await projectService.getById(taskResult.value.projectId);
+          if (projectInfo.ok) {
+            publishEvent(projectInfo.value.workspaceId, REALTIME_EVENTS.TASK_DELETED, {
+              id: taskId,
+              projectId: taskResult.value.projectId,
+            });
+          }
           break;
         }
 
@@ -362,6 +370,11 @@ mcp.post(
 
           if (!moveResult.ok) throw moveResult.error;
           result = moveResult.value;
+
+          const projectInfo = await projectService.getById(taskResult.value.projectId);
+          if (projectInfo.ok) {
+            publishEvent(projectInfo.value.workspaceId, REALTIME_EVENTS.TASK_MOVED, moveResult.value);
+          }
           break;
         }
 
@@ -395,6 +408,11 @@ mcp.post(
           const updatedTask = await taskService.getById(taskId);
           if (!updatedTask.ok) throw updatedTask.error;
           result = updatedTask.value;
+
+          const projectInfo = await projectService.getById(taskResult.value.projectId);
+          if (projectInfo.ok) {
+            publishEvent(projectInfo.value.workspaceId, REALTIME_EVENTS.TASK_UPDATED, updatedTask.value);
+          }
           break;
         }
 

--- a/apps/api/src/routes/tasks.ts
+++ b/apps/api/src/routes/tasks.ts
@@ -371,7 +371,7 @@ tasks.delete('/:taskId', async (c) => {
   }
 
   // Publish WebSocket event
-  publishEvent(project!.workspaceId, 'task:deleted', { id: taskId });
+  publishEvent(project!.workspaceId, 'task:deleted', { id: taskId, projectId: taskResult.value.projectId });
 
   return c.json({ success: true, data: null });
 });

--- a/apps/web/src/hooks/useRealtimeEvents.ts
+++ b/apps/web/src/hooks/useRealtimeEvents.ts
@@ -6,7 +6,7 @@ import { REALTIME_EVENTS } from '@flowtask/shared';
 // Event data types
 interface TaskEventData {
   id: string;
-  projectId: string;
+  projectId?: string;
   timestamp: string;
 }
 
@@ -43,10 +43,25 @@ export function useRealtimeEvents() {
   const handleEvent = useCallback(
     (event: string, data: EventData) => {
       switch (event) {
-        case REALTIME_EVENTS.TASK_CREATED:
+        case REALTIME_EVENTS.TASK_CREATED: {
+          const taskData = data as TaskEventData;
+          if (taskData.projectId) {
+            queryClient.invalidateQueries({ queryKey: ['tasks', taskData.projectId] });
+          }
+          queryClient.invalidateQueries({ queryKey: ['smart-view-execute'] });
+          break;
+        }
+
         case REALTIME_EVENTS.TASK_DELETED: {
           const taskData = data as TaskEventData;
-          queryClient.invalidateQueries({ queryKey: ['tasks', taskData.projectId] });
+          if (taskData.id) {
+            queryClient.invalidateQueries({ queryKey: ['task', taskData.id] });
+          }
+          if (taskData.projectId) {
+            queryClient.invalidateQueries({ queryKey: ['tasks', taskData.projectId] });
+          } else {
+            queryClient.invalidateQueries({ queryKey: ['tasks'] });
+          }
           queryClient.invalidateQueries({ queryKey: ['smart-view-execute'] });
           break;
         }


### PR DESCRIPTION
## Summary
- publish missing SSE events for MCP task mutations in both MCP handlers (move_task, assign_task, delete_task)
- include projectId in REST task:deleted SSE payload
- harden web realtime delete invalidation when payload is missing projectId

## Validation
- bun run --filter @flowtask/api typecheck
- bun run --filter @flowtask/api build
- bun run --filter @flowtask/web typecheck
- bun run --filter @flowtask/web build